### PR TITLE
Fix sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ With this command you can generate a local version for testing:
 ## 🐒 How to use?
 
 ```kotlin
-CardForm.withAccessToken("user_access_token", "current_site_id", "integration_flow_id").build()
+CardForm.Builder.withAccessToken("user_access_token", "current_site_id", "integration_flow_id").build()
     .start("activity_from", "request_code")
 ```


### PR DESCRIPTION
Added the missing `Builder` to fix the sample line of code in the README file.