### PR TITLE
[Fix] Card token model modified and esc state checked

### DIFF
--- a/cardform/src/main/java/com/mercadolibre/android/cardform/data/model/response/CardToken.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/data/model/response/CardToken.kt
@@ -19,5 +19,5 @@ internal data class CardToken(
     val requireEsc: Boolean,
     val securityCodeLength: Int,
     val status: String,
-    val esc: String
+    val esc: String?
 )

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/domain/TokenizeUseCase.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/domain/TokenizeUseCase.kt
@@ -10,7 +10,7 @@ internal class TokenizeUseCase(
 ) : UseCase<CardInfoBody, CardTokenModel>() {
 
     override suspend fun doExecute(param: CardInfoBody) =
-        tokenizeRepository.tokenizeCard(param).map { CardTokenModel(it.id, it.esc) }
+        tokenizeRepository.tokenizeCard(param).map { CardTokenModel(it.id, it.esc.orEmpty()) }
 }
 
 data class CardTokenModel(


### PR DESCRIPTION
Debido a que Gson [no conoce de nulleabilidad en kotlin](https://medium.com/swlh/using-gson-with-kotlins-non-null-types-468b1c66bd8b), cuando un valor no viene o es null este le setea null sin problemas. Para solucionar este problema hay que armar un Factory en el GsonBuilder.
Lo que se hizo fue corregir el modelo esperado y devolver vació si esc es null.