### PR TITLE
correction in the mask

### DIFF
--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/custom/InputFormEditText.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/custom/InputFormEditText.kt
@@ -207,10 +207,12 @@ internal class InputFormEditText(context: Context, attrs: AttributeSet?, defStyl
                     }
 
                     update(this, newText.substringBefore('$')) {
-                        if (substring(it.length -1, it.length) == " ")
-                            setText(it.substring(0, it.length - 1))
-                        else
-                            setText(it)
+                        setText(
+                            if (it.takeLast(1).isBlank())
+                                it.dropLast(1)
+                            else
+                                it
+                        )
                     }
                 }
             }

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/custom/InputFormEditText.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/custom/InputFormEditText.kt
@@ -207,7 +207,10 @@ internal class InputFormEditText(context: Context, attrs: AttributeSet?, defStyl
                     }
 
                     update(this, newText.substringBefore('$')) {
-                        setText(it)
+                        if (substring(it.length -1, it.length) == " ")
+                            setText(it.substring(0, it.length - 1))
+                        else
+                            setText(it)
                     }
                 }
             }

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/custom/InputFormEditText.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/custom/InputFormEditText.kt
@@ -169,7 +169,7 @@ internal class InputFormEditText(context: Context, attrs: AttributeSet?, defStyl
     fun setText(text: String) {
         with(input) {
             setText(text)
-            setSelection(text.length)
+            this.text?.let { setSelection(it.length) }
         }
     }
 
@@ -207,12 +207,7 @@ internal class InputFormEditText(context: Context, attrs: AttributeSet?, defStyl
                     }
 
                     update(this, newText.substringBefore('$')) {
-                        setText(
-                            if (it.takeLast(1).isBlank())
-                                it.dropLast(1)
-                            else
-                                it
-                        )
+                        setText(it)
                     }
                 }
             }


### PR DESCRIPTION
Correction in the mask of the card number.

Este PR es una corrección en la máscara del número de tarjeta, sucede que siguiendo unos pocos pasos al montar la máscara se ingresa un carácter vacío y se bloquea la aplicación.

sigue el error en 
- bugsnag: https://app.bugsnag.com/mercadolibre/mercado-pago-android/errors/5c8996b2d4dc440019961e0a?event_id=60ca57dc007ef4375e550000&i=jr&m=ci

- Jira: https://mercadolibre.atlassian.net/secure/RapidBoard.jspa?rapidView=2743&projectKey=PXN&modal=detail&selectedIssue=PXN-2096

Follows the simulation of the error:
![simulate_error](https://user-images.githubusercontent.com/84389392/122972336-689a4e00-d366-11eb-89ef-71d72db0f99a.gif)

