### PR TITLE
Move data classes to package model. To keep the rule

### DIFF
--- a/cardform/src/main/java/com/mercadolibre/android/cardform/CardForm.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/CardForm.kt
@@ -5,11 +5,11 @@ import android.os.Parcel
 import android.os.Parcelable
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import com.mercadolibre.android.cardform.data.model.body.CardInfoDto
 import com.mercadolibre.android.cardform.presentation.ui.CardFormActivity
 import com.mercadolibre.android.cardform.presentation.ui.FragmentNavigationController
 import com.mercadolibre.android.cardform.service.CardFormIntent
 import com.mercadolibre.android.cardform.service.CardFormService
-import kotlinx.android.parcel.Parcelize
 import java.util.*
 
 internal const val CARD_FORM_EXTRA = "card_form"
@@ -150,29 +150,3 @@ open class CardForm : Parcelable {
         }
     }
 }
-
-@Parcelize
-data class CardInfoDto(
-        val flowId: String,
-        val vertical: String,
-        val flowType: String,
-        var bin: String,
-        val callerId: String,
-        val clientId: String,
-        val siteId: String,
-        val odr: Boolean,
-        val items: List<ItemDto>
-) : Parcelable
-
-@Parcelize
-data class ItemDto(
-    val id: String
-) : Parcelable
-
-@Parcelize
-data class CardResultDto(
-    val cardId: String,
-    val bin: String,
-    val paymentType: String,
-    val lastFourDigits: String
-) : Parcelable

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/data/model/body/CardInfoDto.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/data/model/body/CardInfoDto.kt
@@ -1,0 +1,22 @@
+package com.mercadolibre.android.cardform.data.model.body
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class CardInfoDto(
+    val flowId: String,
+    val vertical: String,
+    val flowType: String,
+    var bin: String,
+    val callerId: String,
+    val clientId: String,
+    val siteId: String,
+    val odr: Boolean,
+    val items: List<ItemDto>
+) : Parcelable
+
+@Parcelize
+data class ItemDto(
+    val id: String
+) : Parcelable

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/data/model/response/CardResultDto.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/data/model/response/CardResultDto.kt
@@ -1,0 +1,12 @@
+package com.mercadolibre.android.cardform.data.model.response
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class CardResultDto(
+    val cardId: String,
+    val bin: String,
+    val paymentType: String,
+    val lastFourDigits: String
+) : Parcelable

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/data/repository/CardRepositoryImpl.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/data/repository/CardRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.mercadolibre.android.cardform.data.repository
 
 import com.mercadolibre.android.cardform.BuildConfig
-import com.mercadolibre.android.cardform.CardInfoDto
 import com.mercadolibre.android.cardform.data.model.response.RegisterCard
 import com.mercadolibre.android.cardform.data.service.CardService
 import com.mercadolibre.android.cardform.network.exceptions.ExcludePaymentException
+import com.mercadolibre.android.cardform.data.model.body.CardInfoDto
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/data/service/CardService.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/data/service/CardService.kt
@@ -1,7 +1,7 @@
 package com.mercadolibre.android.cardform.data.service
 
-import com.mercadolibre.android.cardform.CardInfoDto
 import com.mercadolibre.android.cardform.data.model.response.RegisterCard
+import com.mercadolibre.android.cardform.data.model.body.CardInfoDto
 import retrofit2.Response
 import retrofit2.http.*
 

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/di/module/RepositoryModule.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/di/module/RepositoryModule.kt
@@ -1,6 +1,5 @@
 package com.mercadolibre.android.cardform.di.module
 
-import com.mercadolibre.android.cardform.CardInfoDto
 import com.mercadolibre.android.cardform.data.mapper.FinishInscriptionBodyMapper
 import com.mercadolibre.android.cardform.data.repository.*
 import com.mercadolibre.android.cardform.data.service.CardAssociationService
@@ -8,6 +7,7 @@ import com.mercadolibre.android.cardform.data.service.CardService
 import com.mercadolibre.android.cardform.data.service.FinishInscriptionService
 import com.mercadolibre.android.cardform.data.service.InscriptionService
 import com.mercadolibre.android.cardform.data.service.TokenizeService
+import com.mercadolibre.android.cardform.data.model.body.CardInfoDto
 import retrofit2.Retrofit
 
 internal class RepositoryModule(

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/model/StateUi.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/model/StateUi.kt
@@ -1,6 +1,6 @@
 package com.mercadolibre.android.cardform.presentation.model
 
-import com.mercadolibre.android.cardform.CardResultDto
+import com.mercadolibre.android.cardform.data.model.response.CardResultDto
 
 internal sealed class StateUi {
     object UiLoading: StateUi()

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -16,6 +16,7 @@ import com.meli.android.carddrawer.model.CardDrawerView
 import com.meli.android.carddrawer.model.CardUI
 import com.mercadolibre.android.cardform.*
 import com.mercadolibre.android.cardform.base.RootFragment
+import com.mercadolibre.android.cardform.data.model.response.CardResultDto
 import com.mercadolibre.android.cardform.di.viewModel
 import com.mercadolibre.android.cardform.presentation.extensions.*
 import com.mercadolibre.android.cardform.presentation.factory.ObjectStepFactory

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/viewmodel/InputFormViewModel.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/viewmodel/InputFormViewModel.kt
@@ -3,10 +3,10 @@ package com.mercadolibre.android.cardform.presentation.viewmodel
 import androidx.lifecycle.MutableLiveData
 import android.content.Context
 import android.os.Bundle
-import com.mercadolibre.android.cardform.CardResultDto
 import com.mercadolibre.android.cardform.internal.LifecycleListener
 import com.mercadolibre.android.cardform.base.BaseViewModel
 import com.mercadolibre.android.cardform.base.getOrElse
+import com.mercadolibre.android.cardform.data.model.response.CardResultDto
 import com.mercadolibre.android.cardform.data.model.esc.Device
 import com.mercadolibre.android.cardform.data.model.response.CardUi
 import com.mercadolibre.android.cardform.data.model.response.Issuer


### PR DESCRIPTION
Se mueven `data clases` al paquete `model` para mantener la regla del `proguard`.