### PR TITLE
[CHO-7314] customizable toolbar text style

### DIFF
--- a/cardform/src/main/res/layout/app_bar.xml
+++ b/cardform/src/main/res/layout/app_bar.xml
@@ -22,13 +22,11 @@
 
         <TextView
             android:id="@+id/title"
+            style="@style/ToolbarTextView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/ui_2m"
             android:text="@string/cf_generic_title_app_bar"
-            android:textColor="@color/cf_action_bar_text"
-            style="@style/ToolbarTextView"
-            android:layout_marginEnd="@dimen/ui_2m" />
+            android:textColor="@color/cf_action_bar_text" />
 
     </androidx.appcompat.widget.Toolbar>
 

--- a/cardform/src/main/res/values/styles.xml
+++ b/cardform/src/main/res/values/styles.xml
@@ -38,6 +38,8 @@
     </style>
 
     <style name="ToolbarTextView" parent="MLFont.Bold.Semi">
+        <item name="android:textSize">@dimen/ui_2m</item>
+        <item name="android:layout_marginEnd">@dimen/ui_2m</item>
         <!-- Customize your style here. -->
     </style>
 


### PR DESCRIPTION
Se mueven los atributos `textSize` y `layout_marginEnd` al estilo predefinido del toolbar. Haciendo éste más personalizable desde otras dependencias.

