### PR TITLE
PXN-3687: Fix the bug por illegalStateException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## VERSION 2.4.0
 _30_06_2022_
-- Fix - The supportManagerFragment is changed by the childManagerFragment into CardFormFragment
+- Fix - a delay of 1 second is added to give time to finish the pending transactions in the fragment
 
 ## VERSION 2.4.0
 _28_04_2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
 ## VERSION 2.4.0
-_30_06_2022_
-- Fix - a delay of 1 second is added to give time to finish the pending transactions in the fragment
-
-## VERSION 2.4.0
 _28_04_2022_
 - Enhancement - Support for 8-digit bins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## VERSION 2.4.0
+_30_06_2022_
+- Fix - The supportManagerFragment is changed by the childManagerFragment into CardFormFragment
+
+## VERSION 2.4.0
 _28_04_2022_
 - Enhancement - Support for 8-digit bins
 

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -14,7 +14,7 @@ object Versions {
 
     const val constraintLayout = "2.0.4"
     const val gradlePlugin = "4.0.1"
-    const val kotlin = "1.3.71"
+    const val kotlin = "1.5.32"
     const val kotlinCoroutines = "1.3.0"
     const val picassoDiskCache = "1.+"
     const val pxAddons = "4.+"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -9,7 +9,7 @@ object Versions {
     const val material = "1.0.0"
     const val okHttp = "3.12.10"
     const val sdkVersion = 30
-    const val minSdkVersion = 21
+    const val minSdkVersion = 23
     const val buildTools = "30.0.2"
 
     const val constraintLayout = "2.0.4"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -9,12 +9,12 @@ object Versions {
     const val material = "1.0.0"
     const val okHttp = "3.12.10"
     const val sdkVersion = 30
-    const val minSdkVersion = 23
+    const val minSdkVersion = 21
     const val buildTools = "30.0.2"
 
     const val constraintLayout = "2.0.4"
     const val gradlePlugin = "4.0.1"
-    const val kotlin = "1.5.32"
+    const val kotlin = "1.3.71"
     const val kotlinCoroutines = "1.3.0"
     const val picassoDiskCache = "1.+"
     const val pxAddons = "4.+"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -9,12 +9,12 @@ object Versions {
     const val material = "1.0.0"
     const val okHttp = "3.12.10"
     const val sdkVersion = 30
-    const val minSdkVersion = 21
+    const val minSdkVersion = 23
     const val buildTools = "30.0.2"
 
     const val constraintLayout = "2.0.4"
     const val gradlePlugin = "4.0.1"
-    const val kotlin = "1.3.71"
+    const val kotlin = "1.5.32"
     const val kotlinCoroutines = "1.3.0"
     const val picassoDiskCache = "1.+"
     const val pxAddons = "4.+"

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -14,21 +14,43 @@ import com.meli.android.carddrawer.configuration.DefaultCardConfiguration
 import com.meli.android.carddrawer.model.CardAnimationType
 import com.meli.android.carddrawer.model.CardDrawerView
 import com.meli.android.carddrawer.model.CardUI
-import com.mercadolibre.android.cardform.*
+import com.mercadolibre.android.cardform.CARD_FORM_EXTRA
+import com.mercadolibre.android.cardform.CardForm
+import com.mercadolibre.android.cardform.EXIT_ANIM_EXTRA
+import com.mercadolibre.android.cardform.R
 import com.mercadolibre.android.cardform.base.RootFragment
 import com.mercadolibre.android.cardform.data.model.response.CardResultDto
 import com.mercadolibre.android.cardform.di.viewModel
-import com.mercadolibre.android.cardform.presentation.extensions.*
+import com.mercadolibre.android.cardform.presentation.extensions.fadeIn
+import com.mercadolibre.android.cardform.presentation.extensions.fadeOut
+import com.mercadolibre.android.cardform.presentation.extensions.goneDuringAnimation
+import com.mercadolibre.android.cardform.presentation.extensions.nonNullObserve
+import com.mercadolibre.android.cardform.presentation.extensions.postDelayed
+import com.mercadolibre.android.cardform.presentation.extensions.pushDownOut
+import com.mercadolibre.android.cardform.presentation.extensions.pushUpIn
+import com.mercadolibre.android.cardform.presentation.extensions.slideLeftIn
+import com.mercadolibre.android.cardform.presentation.extensions.slideRightIn
+import com.mercadolibre.android.cardform.presentation.extensions.slideRightOut
 import com.mercadolibre.android.cardform.presentation.factory.ObjectStepFactory
 import com.mercadolibre.android.cardform.presentation.helpers.KeyboardHelper
-import com.mercadolibre.android.cardform.presentation.model.*
+import com.mercadolibre.android.cardform.presentation.model.CardDrawerData
+import com.mercadolibre.android.cardform.presentation.model.CardFilledData
+import com.mercadolibre.android.cardform.presentation.model.CardState
 import com.mercadolibre.android.cardform.presentation.model.StateUi.UiLoading
+import com.mercadolibre.android.cardform.presentation.model.UiError
+import com.mercadolibre.android.cardform.presentation.model.UiResult
 import com.mercadolibre.android.cardform.presentation.ui.custom.ProgressFragment
 import com.mercadolibre.android.cardform.presentation.ui.formentry.FormType
 import com.mercadolibre.android.cardform.presentation.viewmodel.InputFormViewModel
-import kotlinx.android.synthetic.main.app_bar.*
-import kotlinx.android.synthetic.main.cf_card.*
-import kotlinx.android.synthetic.main.fragment_card_form.*
+import kotlinx.android.synthetic.main.app_bar.progress
+import kotlinx.android.synthetic.main.app_bar.toolbar
+import kotlinx.android.synthetic.main.cf_card.cardContainer
+import kotlinx.android.synthetic.main.cf_card.inputViewPager
+import kotlinx.android.synthetic.main.fragment_card_form.appBar
+import kotlinx.android.synthetic.main.fragment_card_form.back
+import kotlinx.android.synthetic.main.fragment_card_form.buttonContainer
+import kotlinx.android.synthetic.main.fragment_card_form.next
+import kotlinx.android.synthetic.main.fragment_card_form.rootCardForm
 
 /**
  * A simple [Fragment] subclass.
@@ -93,11 +115,8 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        println("TEST BUG ONVIEWCREATED")
 
         cardDrawer = view.findViewById(R.id.cardDrawer)
-        println("TEST BUG savedInstance is null? -> $savedInstanceState")
-        println("TEST BUG savedInstance is null? -> ${savedInstanceState == null}")
         if (savedInstanceState == null) {
             viewModel.trackInit()
             cardDrawer.show(object : DefaultCardConfiguration(context!!) {
@@ -304,18 +323,16 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
     }
 
     private fun returnResult(data: CardResultDto, resultCode: Int) {
-        println("TEST BUG returnResult -> ")
-        println("TEST BUG returnResult supportFragmentManager ${activity?.supportFragmentManager}")
         activity?.apply {
-            println("TEST BUG returnResult Fragmentactivity ${this.supportFragmentManager}")
-            println("TEST BUG returnResult Fragmentactivity ${this.supportFragmentManager}")
             if (fromFragment) {
-                supportFragmentManager.popBackStackImmediate()
-                getCurrentFragment(supportFragmentManager)?.onActivityResult(
-                    requestCode,
-                    resultCode,
-                    buildResultIntent(data)
-                )
+                postDelayed((1000L)) {
+                    getCurrentFragment(supportFragmentManager)?.onActivityResult(
+                        requestCode,
+                        resultCode,
+                        buildResultIntent(data)
+                    )
+                    supportFragmentManager.popBackStackImmediate()
+                }
             } else {
                 setResult(resultCode, buildResultIntent(data))
                 finish()

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -305,7 +305,7 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
         activity?.apply {
             if (fromFragment) {
                 childFragmentManager.popBackStackImmediate()
-                getCurrentFragment(supportFragmentManager)?.onActivityResult(
+                getCurrentFragment(childFragmentManager)?.onActivityResult(
                     requestCode,
                     resultCode,
                     buildResultIntent(data)

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -325,8 +325,8 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
     private fun returnResult(data: CardResultDto, resultCode: Int) {
         activity?.apply {
             if (fromFragment) {
-                supportFragmentManager.popBackStackImmediate()
                 postDelayed((1000L)) {
+                    supportFragmentManager.popBackStackImmediate()
                     getCurrentFragment(supportFragmentManager)?.onActivityResult(
                         requestCode,
                         resultCode,

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -304,7 +304,7 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
     private fun returnResult(data: CardResultDto, resultCode: Int) {
         activity?.apply {
             if (fromFragment) {
-                supportFragmentManager.popBackStackImmediate()
+                childFragmentManager.popBackStackImmediate()
                 getCurrentFragment(supportFragmentManager)?.onActivityResult(
                     requestCode,
                     resultCode,

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -325,14 +325,14 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
     private fun returnResult(data: CardResultDto, resultCode: Int) {
         activity?.apply {
             if (fromFragment) {
-                postDelayed((1000L)) {
-                    supportFragmentManager.popBackStackImmediate()
+                supportFragmentManager.addOnBackStackChangedListener {
                     getCurrentFragment(supportFragmentManager)?.onActivityResult(
                         requestCode,
                         resultCode,
                         buildResultIntent(data)
                     )
                 }
+                supportFragmentManager.popBackStack()
             } else {
                 setResult(resultCode, buildResultIntent(data))
                 finish()

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -325,13 +325,13 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
     private fun returnResult(data: CardResultDto, resultCode: Int) {
         activity?.apply {
             if (fromFragment) {
+                supportFragmentManager.popBackStackImmediate()
                 postDelayed((1000L)) {
                     getCurrentFragment(supportFragmentManager)?.onActivityResult(
                         requestCode,
                         resultCode,
                         buildResultIntent(data)
                     )
-                    supportFragmentManager.popBackStackImmediate()
                 }
             } else {
                 setResult(resultCode, buildResultIntent(data))

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -93,9 +93,11 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        println("TEST BUG ONVIEWCREATED")
 
         cardDrawer = view.findViewById(R.id.cardDrawer)
-
+        println("TEST BUG savedInstance is null? -> $savedInstanceState")
+        println("TEST BUG savedInstance is null? -> ${savedInstanceState == null}")
         if (savedInstanceState == null) {
             viewModel.trackInit()
             cardDrawer.show(object : DefaultCardConfiguration(context!!) {
@@ -302,10 +304,14 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
     }
 
     private fun returnResult(data: CardResultDto, resultCode: Int) {
+        println("TEST BUG returnResult -> ")
+        println("TEST BUG returnResult supportFragmentManager ${activity?.supportFragmentManager}")
         activity?.apply {
+            println("TEST BUG returnResult Fragmentactivity ${this.supportFragmentManager}")
+            println("TEST BUG returnResult Fragmentactivity ${this.supportFragmentManager}")
             if (fromFragment) {
-                childFragmentManager.popBackStackImmediate()
-                getCurrentFragment(childFragmentManager)?.onActivityResult(
+                supportFragmentManager.popBackStackImmediate()
+                getCurrentFragment(supportFragmentManager)?.onActivityResult(
                     requestCode,
                     resultCode,
                     buildResultIntent(data)

--- a/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
+++ b/cardform/src/main/java/com/mercadolibre/android/cardform/presentation/ui/CardFormFragment.kt
@@ -325,13 +325,16 @@ internal class CardFormFragment : RootFragment<InputFormViewModel>() {
     private fun returnResult(data: CardResultDto, resultCode: Int) {
         activity?.apply {
             if (fromFragment) {
-                supportFragmentManager.addOnBackStackChangedListener {
-                    getCurrentFragment(supportFragmentManager)?.onActivityResult(
-                        requestCode,
-                        resultCode,
-                        buildResultIntent(data)
-                    )
-                }
+                supportFragmentManager.addOnBackStackChangedListener(object : FragmentManager.OnBackStackChangedListener {
+                    override fun onBackStackChanged() {
+                        getCurrentFragment(supportFragmentManager)?.onActivityResult(
+                            requestCode,
+                            resultCode,
+                            buildResultIntent(data)
+                        )
+                        supportFragmentManager.removeOnBackStackChangedListener(this)
+                    }
+                })
                 supportFragmentManager.popBackStack()
             } else {
                 setResult(resultCode, buildResultIntent(data))


### PR DESCRIPTION
a handler is added to give a time to finish loading the fragment when it returns to the foreground, otherwise an IllegalStateException "FragmentManager is already executing transactions" occurs.

How to replicate the crash:
1. Filling in the data
2. Lastly, when you fill out the DNI, at the next moment you must block or put the app in the background immediately

Prueba 1

![WhatsApp Video 2022-06-29 at 7 04 28 PM (1)](https://user-images.githubusercontent.com/95652303/176566083-512ed417-d10c-4cc2-a3f8-9c2a0394e421.gif)

Prueba 2


![WhatsApp Video 2022-06-29 at 7 04 35 PM (1)](https://user-images.githubusercontent.com/95652303/176566187-0ea6197c-a43c-4007-b574-e20d03653860.gif)


https://mercadolibre.atlassian.net/browse/PXN-3687?atlOrigin=eyJpIjoiYjk1ZmEzOGY0NWFkNDcyNWI1OGI1YjJhNWYwZmU3YTMiLCJwIjoiaiJ9